### PR TITLE
Large last.fm update

### DIFF
--- a/modules/lastfm.js
+++ b/modules/lastfm.js
@@ -16,7 +16,7 @@ const commands = {
 	//Time periods
 	"weekly": ["week", "7-day", "7day", "weekly"],
 	"monthly": ["month", "1-month", "1month", "monthly"],
-	"threeMonth": ["3-month", "3month"],
+	"threeMonth": ["three-month", "3-month", "3month"],
 	"sixMonth": ["half-year", "6-month", "6month", "halfyear"],
 	"yearly": ["year", "12-month", "12month", "yearly"]
 };
@@ -39,7 +39,7 @@ module.exports = (bot = Discord.Client) => {
 		let command = messageArray[0];
 		let args = messageArray.slice(1);
 
-		if (![`${prefix}lastfm`, `${prefix}lf`].includes(command)) return;
+		if (![`${prefix}lastfm`, `${prefix}lf`, `${prefix}fm`].includes(command)) return;
 
 		notRegisteredAlert = `Please register your last.fm by using ${prefix}lf set <username>`;
 


### PR DESCRIPTION
- not async anymore
- better getting target user of the command
- change formatting of top ___ lists, recent, etc.
- add photo to top ___ and recent embeds
- play count display on now playing
- add link to profile, and country name on to lastfm profile embed
- view someone else lastfm profile
- now playing only retrieves 2 instead of 10 to get response faster
- now playing show heart next to song name if the user has Loved that track on lastfm
- recent only shows 10 instead of 11, the 11th song is the now playing song and is now shown separately
- urls cleanup
- other refactoring to reduce complexity and make more readable