### PR TITLE
Remove unused dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,8 @@
 	  "axios": "0.18.0",
 	  "cassette": "^3.0.3",
 	  "discord.js": "^11.3.2",
-	  "discord.js-music": "^2.1.0",
-	  "discord.js-music-v11": "^1.3.4",
-	  "discord.js-musicbot-addon": "^1.10.3",
 	  "enmap": "^0.4.2",
 	  "enmap-level": "^1.0.0",
-	  "ffmpeg-binaries": "3.2.2-3",
-	  "opusscript": "0.0.6",
 	  "quick.db": "^3.0.3",
 	  "sqlite": "^2.9.1"
   }


### PR DESCRIPTION
Removed music bot dependencies as they are not used:

* `discord.js-music`
* `discord.js-music-v11`
* `discord.js-musicbot-addon`
* `ffmpeg-binaries`
* `opusscript`