### PR TITLE
Preserve notification message code blocks

### DIFF
--- a/modules/notifications.js
+++ b/modules/notifications.js
@@ -514,7 +514,7 @@ module.exports = (bot = Discord.Client) => {
 					notifications.forEach((keywordSet, userID) => {
 						const member = guild.members.get(userID);
 						if (!member) return;
-						let msg = message.content;
+						let msg = message.content.replace(/`/g, "\u200B`");
 						const keywords = Array.from(keywordSet).map(key => `\`${key}\``).join(", ");
 						/* let embed = new Discord.RichEmbed()
 							.setAuthor(message.author.username, message.author.displayAvatarURL.split("?")[0])


### PR DESCRIPTION
Adds zero width spaces between extra backticks in message content to prevent code blocks from modification.

Used ZWS as escaping cannot be done in code blocks.